### PR TITLE
v0.1.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,6 @@ platform:
   - x64
 
 cache:
-  - node_modules
-  - '%APPDATA%\npm-cache'
-  - '%USERPROFILE%\.electron'
-  - '%USERPROFILE%\AppData\Local\Yarn\cache'
-  - '%USERPROFILE%\AppData\Local\electron-builder\cache'
 
 init:
   - git config --global core.autocrlf input

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,19 +11,22 @@ platform:
   - x64
 
 cache:
+  - node_modules
+  - '%APPDATA%\npm-cache'
+  - '%USERPROFILE%\.electron'
+  - '%USERPROFILE%\AppData\Local\electron-builder\cache'
 
 init:
   - git config --global core.autocrlf input
 
 install:
   - ps: Install-Product node 8 x64
-  - choco install yarn --ignore-dependencies
   - git reset --hard HEAD
-  - yarn
+  - npm install
   - node --version
 
 build_script:
   #- yarn test
-  - yarn build
+  - npm run build
 
 test: off

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "axion": "^0.1.0",
     "axios": "^0.18.0",
     "bootstrap": "^4.0.0",
+    "electron-default-menu": "^1.0.1",
     "iota.lib.js": "^0.4.7",
     "jquery": "^3.3.1",
     "popper.js": "^1.12.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iota-adress-balance",
-  "version": "v0.1.4",
+  "version": "v0.1.5",
   "author": "Shogo Takata <peshogo@gmail.com>",
   "description": "an app that shows the iota balance of each address",
   "license": "MIT",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, Menu, shell } from 'electron'
+import defaultMenu from 'electron-default-menu'
 
 /**
  * Set `__static` path to static files in production
@@ -33,6 +34,11 @@ function createWindow () {
 }
 
 app.on('ready', createWindow)
+
+app.on('ready', () => {
+  const menu = defaultMenu(app, shell)
+  Menu.setApplicationMenu(Menu.buildFromTemplate(menu))
+})
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,6 +2864,10 @@ electron-debug@^1.4.0:
     electron-is-dev "^0.3.0"
     electron-localshortcut "^3.0.0"
 
+electron-default-menu@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/electron-default-menu/-/electron-default-menu-1.0.1.tgz#3173c5018eb507404fec63bdf3b78c38eedba808"
+
 electron-devtools-installer@^2.2.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.3.tgz#58b9a4ec507377bc46e091cd43714188e0c369be"


### PR DESCRIPTION
fix: can't copy and paste on mac
fixed it by adding the electron default menu